### PR TITLE
fix reserved name issue

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/dagGeneration/WorkflowVisitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dagGeneration/WorkflowVisitor.groovy
@@ -110,7 +110,9 @@ class WorkflowVisitor {
         "groupKey",
         "multiMapCriteria",
         "sendMail",
-        "tuple"
+        "tuple",
+        "log",
+        "random"
     ])
 
     String workflowName
@@ -489,9 +491,15 @@ class WorkflowVisitor {
 
                 int idx = 0
                 ret = entity.outputs.collect {
+                    String name = it
+                    if (it in implicitFunctionNames) {
+                        // todo(ayush): this sucks
+                        name = "_latch_placeholder_$it"
+                    }
+
                     new ExpressionStatement(
                         new BinaryExpression(
-                            new VariableExpression(it),
+                            new VariableExpression(name),
                             Token.newSymbol("=", 0, 0),
                             new BinaryExpression(
                                 outExpr,
@@ -643,9 +651,15 @@ class WorkflowVisitor {
                 }
 
                 ret = outputNames.collect {
+                    String name = it
+                    if (it in implicitFunctionNames) {
+                        // todo(ayush): this sucks
+                        name = "_latch_placeholder_$it"
+                    }
+
                     new ExpressionStatement(
                         new BinaryExpression(
-                            new VariableExpression(it),
+                            new VariableExpression(name),
                             Token.newSymbol("=", 0, 0),
                             new PropertyExpression(
                                 new VariableExpression("res"),

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowDef.groovy
@@ -243,10 +243,9 @@ class WorkflowDef extends BindableDef implements ChainableDef, IterableDef, Exec
                         if (res.size() != 1) {
                             log.info "No output found for channel $name"
                             builder([])
-                            return
+                        } else {
+                            builder(res[0])
                         }
-
-                        builder(res[0])
                     } else {
                         builder(res)
                     }

--- a/modules/nextflow/src/main/groovy/nextflow/script/WorkflowDef.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/script/WorkflowDef.groovy
@@ -228,6 +228,10 @@ class WorkflowDef extends BindableDef implements ChainableDef, IterableDef, Exec
                 List<Map> res = []
 
                 def name = ch.key
+                if (name.startsWith("_latch_placeholder_")) {
+                    name = name.substring("_latch_placeholder_".length())
+                }
+
                 def channel = ch.value
 
                 boolean isValueChannel = channel instanceof DataflowExpression
@@ -238,6 +242,7 @@ class WorkflowDef extends BindableDef implements ChainableDef, IterableDef, Exec
                     if (isValueChannel) {
                         if (res.size() != 1) {
                             log.info "No output found for channel $name"
+                            builder([])
                             return
                         }
 

--- a/modules/nf-commons/src/main/nextflow/Const.groovy
+++ b/modules/nf-commons/src/main/nextflow/Const.groovy
@@ -57,12 +57,12 @@ class Const {
     /**
      * The app build time as linux/unix timestamp
      */
-    static public final long APP_TIMESTAMP = 1712780476723
+    static public final long APP_TIMESTAMP = 1713305360244
 
     /**
      * The app build number
      */
-    static public final int APP_BUILDNUM = 7005
+    static public final int APP_BUILDNUM = 7014
 
     /**
      * The app build time string relative to UTC timezone

--- a/modules/nf-commons/src/main/nextflow/Const.groovy
+++ b/modules/nf-commons/src/main/nextflow/Const.groovy
@@ -57,12 +57,12 @@ class Const {
     /**
      * The app build time as linux/unix timestamp
      */
-    static public final long APP_TIMESTAMP = 1713305360244
+    static public final long APP_TIMESTAMP = 1713374230113
 
     /**
      * The app build number
      */
-    static public final int APP_BUILDNUM = 7014
+    static public final int APP_BUILDNUM = 7015
 
     /**
      * The app build time string relative to UTC timezone


### PR DESCRIPTION
having process output named `log`, `tuple`, etc. would break bc those names are reserved