### PR TITLE
small broken strings dag fix

### DIFF
--- a/modules/nextflow/src/main/groovy/nextflow/dagGeneration/WorkflowVisitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dagGeneration/WorkflowVisitor.groovy
@@ -1004,8 +1004,6 @@ class WorkflowVisitor {
                 return !expr.expressions.collect({ !isLiteralExpression(it) }).any()
             case PropertyExpression:
                 return isLiteralExpression(expr.objectExpression)
-            case NotExpression:
-                return isLiteralExpression(expr.expression)
             case BooleanExpression:
                 return isLiteralExpression(expr.expression)
             case ListExpression:
@@ -1147,9 +1145,7 @@ class WorkflowVisitor {
                 def stmt = s as IfStatement
 
                 def bool = stmt.booleanExpression
-
                 def condProducer = visitExpression(bool)
-                log.info "$bool.text -> ${condProducer?.vertex.call.text}"
 
                 def sub = bool
                 if (condProducer != null) {

--- a/modules/nextflow/src/main/groovy/nextflow/dagGeneration/WorkflowVisitor.groovy
+++ b/modules/nextflow/src/main/groovy/nextflow/dagGeneration/WorkflowVisitor.groovy
@@ -942,7 +942,7 @@ class WorkflowVisitor {
     }
 
     ScopeVariable visitBooleanExpression(BooleanExpression expr) {
-        def resExpr = new NotExpression(new NotExpression(expr.expression))
+        def resExpr = new NotExpression(new NotExpression(expr))
 
         def dep = visitExpression(expr.expression)
         if (dep != null) {
@@ -1004,6 +1004,8 @@ class WorkflowVisitor {
                 return !expr.expressions.collect({ !isLiteralExpression(it) }).any()
             case PropertyExpression:
                 return isLiteralExpression(expr.objectExpression)
+            case NotExpression:
+                return isLiteralExpression(expr.expression)
             case BooleanExpression:
                 return isLiteralExpression(expr.expression)
             case ListExpression:
@@ -1145,7 +1147,9 @@ class WorkflowVisitor {
                 def stmt = s as IfStatement
 
                 def bool = stmt.booleanExpression
+
                 def condProducer = visitExpression(bool)
+                log.info "$bool.text -> ${condProducer?.vertex.call.text}"
 
                 def sub = bool
                 if (condProducer != null) {

--- a/modules/nf-commons/src/main/nextflow/Const.groovy
+++ b/modules/nf-commons/src/main/nextflow/Const.groovy
@@ -58,12 +58,12 @@ class Const {
      * The app build time as linux/unix timestamp
      */
 
-    static public final long APP_TIMESTAMP = 1713306883757
+    static public final long APP_TIMESTAMP = 1714085664224
 
     /**
      * The app build number
      */
-    static public final int APP_BUILDNUM = 7023
+    static public final int APP_BUILDNUM = 7027
 
     /**
      * The app build time string relative to UTC timezone


### PR DESCRIPTION
Conditions of the form if (!cond) {...} were getting evaluated incorrectly (the ! was getting dropped)
- this is because NotExpression is a subclass of BooleanExpression, so calling `expr.expression` gives `cond` when we really want `!cond`, hence switching to `expr`